### PR TITLE
Fix connection drops in broadcast and source accept loops

### DIFF
--- a/src/threads/http/mod.rs
+++ b/src/threads/http/mod.rs
@@ -25,38 +25,37 @@ pub async fn thread(
     }
   };
 
-  'broadcaster: loop {
+  loop {
     tokio::select! {
-      _ = shutdown_rx.changed() => { break 'broadcaster }
-      Ok((stream, _peer)) = listener.accept() => {
-        let _ = stream.set_nodelay(true);
-        let io = TokioIo::new(stream);
+      _ = shutdown_rx.changed() => break,
+      conn = listener.accept() => match conn {
+        Err(e) => {
+          eprintln!("Accept error: {e}");
+          tokio::time::sleep(TIMEOUT).await; // avoid busy loop
+        }
+        Ok((stream, _peer)) => {
+          let _ = stream.set_nodelay(true);
+          let io = TokioIo::new(stream);
 
-        tokio::task::spawn({
+          tokio::task::spawn({
             let tx = tx.clone();
             let ogg_headers = header.clone();
             let allowed_origins = allowed_origins.clone();
             async move {
               if let Err(err) = http1::Builder::new()
-                .serve_connection(io, service_fn(
-                move |req| {
-                  handle_request(
-                    req,
-                    tx.clone(),
-                    ogg_headers.clone(),
-                    mount,
-                    allowed_origins.clone()
-                  )
-                })
-              ).await {
+                .serve_connection(
+                  io,
+                  service_fn(move |req| {
+                    handle_request(req, tx.clone(), ogg_headers.clone(), mount, allowed_origins.clone())
+                  }),
+                )
+                .await
+              {
                 eprintln!("error serving connection: {err}");
               }
             }
           });
-      }
-      Err(e) = listener.accept() => {
-        eprintln!("Accept error: {e}");
-        tokio::time::sleep(TIMEOUT).await; // avoid busy loop
+        }
       }
     }
   }

--- a/src/threads/ws/mod.rs
+++ b/src/threads/ws/mod.rs
@@ -33,27 +33,29 @@ pub async fn thread(
     }
   };
 
-  'listener: loop {
+  loop {
     tokio::select! {
-      _ = shutdown_rx.changed() => { break 'listener } 
-      Ok((stream, addr)) = server.accept() => {
-        match accept_hdr_async(stream, |req: &Request<_>, res: hyper::Response<()>| {
-
-          // unbox large error
-          validate_headers(req, res, &credentials)
+      _ = shutdown_rx.changed() => break,
+      conn = server.accept() => match conn {
+        Err(e) => {
+          eprintln!("{e}");
+          tokio::time::sleep(TIMEOUT).await;
         }
-        ).await {
-          Ok(mut ws_stream) => {
-            receive_data(&mut ws_stream, header.clone(), tx.clone()).await;
-          },
-          Err(e) => {
-            eprintln!("Handshake failed from {addr}: {e}");
+        Ok((stream, addr)) => {
+          match accept_hdr_async(stream, |req: &Request<_>, res: hyper::Response<()>| {
+            // unbox large error
+            validate_headers(req, res, &credentials)
+          })
+          .await
+          {
+            Ok(mut ws_stream) => {
+              receive_data(&mut ws_stream, header.clone(), tx.clone()).await;
+            }
+            Err(e) => {
+              eprintln!("Handshake failed from {addr}: {e}");
+            }
           }
         }
-      }
-      Err(e) = server.accept() => {
-        eprintln!("{e}");
-        tokio::time::sleep(TIMEOUT).await;
       }
     }
   }


### PR DESCRIPTION
The broadcast server (and the source ingest server) randomly dropped incoming connections. Listeners saw resets / empty replies, and source clients had to retry the handshake. Measured around 30% of connections to the broadcast port were reset under a simple sequential request loop.

Both accept loops used two separate `listener.accept()` arms inside one `tokio::select!`, one matching `Ok(..)` and one matching `Err(..)`. `tokio::select!` polls its branches in randomized order, so whenever the `Err` arm was polled first on a successful accept, the returned `Ok(conn)` failed to match the `Err(..)` pattern. That branch was then disabled for the iteration and the freshly accepted connection was discarded, closing it on the client.

The solution is to accept once per iteration and match on the result inside a single arm.